### PR TITLE
Recommend correct value for `draw_white_space`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Preferences:
   "caret_extra_width": 2,
   "draw_centered": true,
   "draw_indent_guides": false,
-  "draw_white_space": ["none"],
+  "draw_white_space": ["selection_none"],
   "font_face": "Writer",
   "font_size": 16,
   "gutter": false,


### PR DESCRIPTION
Currently proposed value `"draw_white_space": ["none"]` raises errors in the Sublime Text 4 console: «Unknown draw white space option: none». 

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/1469636/124392027-c9753f00-dcf3-11eb-8645-a2b5bc8756d9.png">


It happens because `none` is a modifier that should be applied to the main value (`selection`, `leading`, etc.). The best way to hide the whitespace is `"selection_none"`